### PR TITLE
some simple numpy arrays types can't be copied based only on the type number

### DIFF
--- a/numpy/core/src/multiarray/methods.c
+++ b/numpy/core/src/multiarray/methods.c
@@ -2041,7 +2041,9 @@ array_setstate(PyArrayObject *self, PyObject *args)
                                         PyArray_DESCR(self)->elsize,
                                         datastr, PyArray_DESCR(self)->elsize,
                                         numels, 1, self);
-                if (!PyArray_ISEXTENDED(self)) {
+                if (!(PyArray_ISEXTENDED(self) ||
+                      PyArray_DESCR(self)->metadata ||
+                      PyArray_DESCR(self)->c_metadata)) {
                     fa->descr = PyArray_DescrFromType(
                                     PyArray_DESCR(self)->type_num);
                 }


### PR DESCRIPTION
BUG: some simple numpy arrays types can't be copied based only on the type number

Numpy arrays with metadata (including units for datetime64) can't have their type copied based only on the typenum.  This change is in the array_setstate, where it does byte reversal of data from platforms with a different endian value.
